### PR TITLE
Make settings explicit

### DIFF
--- a/.github/tests/lm_tests.py
+++ b/.github/tests/lm_tests.py
@@ -288,12 +288,7 @@ def test_filter_cascade(setup_models):
 def test_join_cascade(setup_models):
     models = setup_models
     rm = SentenceTransformersRM(model="intfloat/e5-base-v2")
-    lotus.settings.configure(
-        lm=models["gpt-4o-mini"],
-        rm=rm,
-        min_join_cascade_size=10,  # for smaller testings
-        cascade_IS_random_seed=42,
-    )
+    lotus.settings.configure(lm=models["gpt-4o-mini"], rm=rm)
 
     data1 = {
         "School": [
@@ -326,7 +321,12 @@ def test_join_cascade(setup_models):
 
     # Cascade join
     joined_df, stats = df1.sem_join(
-        df2, join_instruction, cascade_args=CascadeArgs(recall_target=0.7, precision_target=0.7), return_stats=True
+        df2,
+        join_instruction,
+        cascade_args=CascadeArgs(
+            recall_target=0.7, precision_target=0.7, min_join_cascade_size=10, cascade_IS_random_seed=42
+        ),
+        return_stats=True,
     )
 
     for pair in expected_pairs:
@@ -337,7 +337,12 @@ def test_join_cascade(setup_models):
 
     # All joins resolved by the large model
     joined_df, stats = df1.sem_join(
-        df2, join_instruction, cascade_args=CascadeArgs(recall_target=1.0, precision_target=1.0), return_stats=True
+        df2,
+        join_instruction,
+        cascade_args=CascadeArgs(
+            recall_target=1.0, precision_target=1.0, min_join_cascade_size=10, cascade_IS_random_seed=42
+        ),
+        return_stats=True,
     )
 
     for pair in expected_pairs:

--- a/examples/op_examples/filter_cascade.py
+++ b/examples/op_examples/filter_cascade.py
@@ -4,8 +4,7 @@ import lotus
 from lotus.models import LM
 from lotus.types import CascadeArgs
 
-
-gpt_35_turbo = LM("gpt-3.5-turbo")
+gpt_35_turbo = LM("gpt-4o-mini")
 gpt_4o = LM("gpt-4o")
 
 lotus.settings.configure(lm=gpt_4o, helper_lm=gpt_35_turbo)

--- a/examples/op_examples/filter_cascade.py
+++ b/examples/op_examples/filter_cascade.py
@@ -4,10 +4,10 @@ import lotus
 from lotus.models import LM
 from lotus.types import CascadeArgs
 
-gpt_35_turbo = LM("gpt-4o-mini")
+gpt_4o_mini = LM("gpt-4o-mini")
 gpt_4o = LM("gpt-4o")
 
-lotus.settings.configure(lm=gpt_4o, helper_lm=gpt_35_turbo)
+lotus.settings.configure(lm=gpt_4o, helper_lm=gpt_4o_mini)
 data = {
     "Course Name": [
         "Probability and Random Processes",

--- a/lotus/sem_ops/cascade_utils.py
+++ b/lotus/sem_ops/cascade_utils.py
@@ -2,30 +2,27 @@ import numpy as np
 from numpy.typing import NDArray
 
 import lotus
+from lotus.types import CascadeArgs
 
 
 def importance_sampling(
     proxy_scores: list[float],
-    sample_percentage: float,
+    cascade_args: CascadeArgs,
 ) -> tuple[NDArray[np.int64], NDArray[np.float64]]:
     """Uses importance sampling and returns the list of indices from which to learn cascade thresholds."""
-    if lotus.settings.cascade_IS_random_seed is not None:
-        np.random.seed(lotus.settings.cascade_IS_random_seed)
+    if cascade_args.cascade_IS_random_seed is not None:
+        np.random.seed(cascade_args.cascade_IS_random_seed)
 
     w = np.sqrt(proxy_scores)
-    is_weight = lotus.settings.cascade_IS_weight
+    is_weight = cascade_args.cascade_IS_weight
     w = is_weight * w / np.sum(w) + (1 - is_weight) * np.ones((len(proxy_scores))) / len(proxy_scores)
 
-    if lotus.settings.cascade_IS_max_sample_range is not None:
-        sample_range = min(lotus.settings.cascade_IS_max_sample_range, len(proxy_scores))
-        sample_w = w[:sample_range]
-        sample_w = sample_w / np.sum(sample_w)
-        indices = np.arange(sample_range)
-    else:
-        sample_w = w
-        indices = np.arange(len(proxy_scores))
+    sample_range = min(cascade_args.cascade_IS_max_sample_range, len(proxy_scores))
+    sample_w = w[:sample_range]
+    sample_w = sample_w / np.sum(sample_w)
+    indices = np.arange(sample_range)
 
-    sample_size = int(sample_percentage * len(proxy_scores))
+    sample_size = int(cascade_args.sampling_percentage * len(proxy_scores))
     sample_indices = np.random.choice(indices, sample_size, p=sample_w)
 
     correction_factors = (1 / len(proxy_scores)) / w
@@ -33,9 +30,9 @@ def importance_sampling(
     return sample_indices, correction_factors
 
 
-def calibrate_llm_logprobs(true_probs: list[float]) -> list[float]:
+def calibrate_llm_logprobs(true_probs: list[float], cascade_args: CascadeArgs) -> list[float]:
     """Transforms true probabilities to calibrate LLM proxies."""
-    num_quantiles = lotus.settings.cascade_num_calibration_quantiles
+    num_quantiles = cascade_args.cascade_num_calibration_quantiles
     quantile_values = np.percentile(true_probs, np.linspace(0, 100, num_quantiles + 1))
     true_probs = list((np.digitize(true_probs, quantile_values) - 1) / num_quantiles)
     true_probs = list(np.clip(true_probs, 0, 1))
@@ -46,9 +43,7 @@ def learn_cascade_thresholds(
     proxy_scores: list[float],
     oracle_outputs: list[bool],
     sample_correction_factors: NDArray[np.float64],
-    recall_target: float,
-    precision_target: float,
-    delta: float,
+    cascade_args: CascadeArgs,
 ) -> tuple[tuple[float, float], int]:
     """Learns cascade thresholds given targets and proxy scores,
     oracle outputs over the sample, and correction factors for the
@@ -97,7 +92,7 @@ def learn_cascade_thresholds(
     best_combination = (1.0, 0.0)  # initial tau_+, tau_-
 
     # Find tau_negative based on recall
-    tau_neg_0 = calculate_tau_neg(sorted_pairs, best_combination[0], recall_target)
+    tau_neg_0 = calculate_tau_neg(sorted_pairs, best_combination[0], cascade_args.recall_target)
     best_combination = (best_combination[0], tau_neg_0)
 
     # Do a statistical correction to get a new target recall
@@ -109,8 +104,8 @@ def learn_cascade_thresholds(
     mean_z2 = float(np.mean(Z2)) if Z2 else 0.0
     std_z2 = float(np.std(Z2)) if Z2 else 0.0
 
-    ub_z1 = UB(mean_z1, std_z1, sample_size, delta / 2)
-    lb_z2 = LB(mean_z2, std_z2, sample_size, delta / 2)
+    ub_z1 = UB(mean_z1, std_z1, sample_size, cascade_args.failure_probability / 2)
+    lb_z2 = LB(mean_z2, std_z2, sample_size, cascade_args.failure_probability / 2)
     if ub_z1 + lb_z2 == 0:  # Avoid division by zero
         corrected_recall_target = 1.0
     else:
@@ -127,8 +122,8 @@ def learn_cascade_thresholds(
         Z = [int(x[1]) for x in sorted_pairs if x[0] >= possible_threshold]
         mean_z = float(np.mean(Z)) if Z else 0.0
         std_z = float(np.std(Z)) if Z else 0.0
-        p_l = LB(mean_z, std_z, len(Z), delta / len(sorted_pairs))
-        if p_l > precision_target:
+        p_l = LB(mean_z, std_z, len(Z), cascade_args.failure_probability / len(sorted_pairs))
+        if p_l > cascade_args.precision_target:
             candidate_thresholds.append(possible_threshold)
 
     best_combination = (max(best_combination[1], min(candidate_thresholds)), best_combination[1])

--- a/lotus/sem_ops/cascade_utils.py
+++ b/lotus/sem_ops/cascade_utils.py
@@ -37,7 +37,7 @@ def calibrate_llm_logprobs(true_probs: list[float]) -> list[float]:
     """Transforms true probabilities to calibrate LLM proxies."""
     num_quantiles = lotus.settings.cascade_num_calibration_quantiles
     quantile_values = np.percentile(true_probs, np.linspace(0, 100, num_quantiles + 1))
-    true_probs = (np.digitize(true_probs, quantile_values) - 1) / num_quantiles
+    true_probs = list((np.digitize(true_probs, quantile_values) - 1) / num_quantiles)
     true_probs = list(np.clip(true_probs, 0, 1))
     return true_probs
 

--- a/lotus/sem_ops/sem_agg.py
+++ b/lotus/sem_ops/sem_agg.py
@@ -164,6 +164,11 @@ class SemAggDataframe:
             pd.DataFrame: The dataframe with the aggregated answer.
         """
 
+        if lotus.settings.lm is None:
+            raise ValueError(
+                "The language model must be an instance of LM. Please configure a valid language model using lotus.settings.configure()"
+            )
+
         lotus.logger.debug(f"User instruction: {user_instruction}")
         if all_cols:
             col_li = list(self._obj.columns)

--- a/lotus/sem_ops/sem_cluster_by.py
+++ b/lotus/sem_ops/sem_cluster_by.py
@@ -37,6 +37,11 @@ class SemClusterByDataframe:
         Returns:
             pd.DataFrame: The DataFrame with the cluster assignments.
         """
+        if lotus.settings.rm is None:
+            raise ValueError(
+                "The retrieval model must be an instance of RM. Please configure a valid retrieval model using lotus.settings.configure()"
+            )
+
         cluster_fn = lotus.utils.cluster(col_name, ncentroids)
         indices = cluster_fn(self._obj, niter, verbose)
 

--- a/lotus/sem_ops/sem_dedup.py
+++ b/lotus/sem_ops/sem_dedup.py
@@ -34,6 +34,11 @@ class SemDedupByDataframe:
         Returns:
             pd.DataFrame: The DataFrame with duplicates removed.
         """
+        if lotus.settings.rm is None:
+            raise ValueError(
+                "The retrieval model must be an instance of RM. Please configure a valid retrieval model using lotus.settings.configure()"
+            )
+
         joined_df = self._obj.sem_sim_join(self._obj, col_name, col_name, len(self._obj), lsuffix="_l", rsuffix="_r")
         dedup_df = joined_df[joined_df["_scores"] > threshold]
         dedup_df = dedup_df[dedup_df[f"{col_name}_l"] != dedup_df[f"{col_name}_r"]]

--- a/lotus/sem_ops/sem_extract.py
+++ b/lotus/sem_ops/sem_extract.py
@@ -95,6 +95,10 @@ class SemExtractDataFrame:
         Returns:
             pd.DataFrame: The dataframe with the new mapped columns.
         """
+        if lotus.settings.lm is None:
+            raise ValueError(
+                "The language model must be an instance of LM. Please configure a valid language model using lotus.settings.configure()"
+            )
 
         # check that column exists
         for column in input_cols:

--- a/lotus/sem_ops/sem_filter.py
+++ b/lotus/sem_ops/sem_filter.py
@@ -174,6 +174,11 @@ class SemFilterDataframe:
         Returns:
             pd.DataFrame | tuple[pd.DataFrame, dict[str, Any]]: The filtered dataframe or a tuple containing the filtered dataframe and statistics.
         """
+        if lotus.settings.lm is None:
+            raise ValueError(
+                "The language model must be an instance of LM. Please configure a valid language model using lotus.settings.configure()"
+            )
+
         stats = {}
         lotus.logger.debug(user_instruction)
         col_li = lotus.nl_expression.parse_cols(user_instruction)
@@ -246,6 +251,7 @@ class SemFilterDataframe:
                 progress_bar_desc="Running helper LM",
             )
             helper_outputs, helper_logprobs = helper_output.outputs, helper_output.logprobs
+            assert helper_logprobs is not None
             formatted_helper_logprobs: LogprobsForFilterCascade = (
                 lotus.settings.helper_lm.format_logprobs_for_filter_cascade(helper_logprobs)
             )

--- a/lotus/sem_ops/sem_index.py
+++ b/lotus/sem_ops/sem_index.py
@@ -30,9 +30,12 @@ class SemIndexDataframe:
         Returns:
             pd.DataFrame: The DataFrame with the index directory saved.
         """
+        if lotus.settings.rm is None:
+            raise ValueError(
+                "The retrieval model must be an instance of RM. Please configure a valid retrieval model using lotus.settings.configure()"
+            )
+
         rm = lotus.settings.rm
-        if rm is None:
-            raise AttributeError("Must set rm in lotus.settings")
         rm.index(self._obj[col_name], index_dir)
         self._obj.attrs["index_dirs"][col_name] = index_dir
         return self._obj

--- a/lotus/sem_ops/sem_join.py
+++ b/lotus/sem_ops/sem_join.py
@@ -130,10 +130,7 @@ def sem_join_cascade(
     col2_label: str,
     model: lotus.models.LM,
     user_instruction: str,
-    recall_target: float,
-    precision_target: float,
-    sampling_percentage: float = 0.1,
-    failure_probability: float = 0.2,
+    cascade_args: CascadeArgs,
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answers: list[bool] | None = None,
     map_instruction: str | None = None,
@@ -154,10 +151,7 @@ def sem_join_cascade(
         col1_label (str): The label for the first column.
         col2_label (str): The label for the second column.
         user_instruction (str): The user instruction for join.
-        recall_target (float): The target recall.
-        precision_target (float): The target precision.
-        sampling_percentage (float): The percentage of the data to sample. Defaults to 0.1.
-        failure_probability (float): The failure probability. Defaults to 0.2.
+        cascade_args (CascadeArgs): The cascade arguments.
         examples_multimodal_data (list[dict[str, Any]] | None): The examples multimodal data. Defaults to None.
         examples_answers (list[bool] | None): The answers for examples. Defaults to None.
         map_instruction (str | None): The map instruction. Defaults to None.
@@ -190,16 +184,13 @@ def sem_join_cascade(
 
     # Determine the join plan
     helper_high_conf, helper_low_conf, num_helper_high_conf_neg, join_optimization_cost = join_optimizer(
-        recall_target,
-        precision_target,
         l1,
         l2,
         col1_label,
         col2_label,
         model,
         user_instruction,
-        sampling_percentage=sampling_percentage,
-        failure_probability=failure_probability,
+        cascade_args,
         examples_multimodal_data=examples_multimodal_data,
         examples_answers=examples_answers,
         map_instruction=map_instruction,
@@ -353,16 +344,13 @@ def map_l1_to_l2(
 
 
 def join_optimizer(
-    recall_target: float,
-    precision_target: float,
     l1: pd.Series,
     l2: pd.Series,
     col1_label: str,
     col2_label: str,
     model: lotus.models.LM,
     user_instruction: str,
-    sampling_percentage: float = 0.1,
-    failure_probability: float = 0.2,
+    cascade_args: CascadeArgs,
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answers: list[bool] | None = None,
     map_instruction: str | None = None,
@@ -376,15 +364,12 @@ def join_optimizer(
     while satisfying the recall and precision target.
 
     Args:
-        recall_target (float): The target recall.
-        precision_target (float): The target precision.
         l1 (pd.Series): The first series.
         l2 (pd.Series): The second series.
         col1_label (str): The label for the first column.
         col2_label (str): The label for the second column.
         user_instruction (str): The user instruction for join.
-        sampling_percentage (float): The percentage of the data to sample. Defaults to 0.1.
-        failure_probability (float): The failure probability. Defaults to 0.2.
+        cascade_args (CascadeArgs): The cascade arguments.
         examples_multimodal_data (list[dict[str, Any]] | None): The examples multimodal data. Defaults to None.
         examples_answers (list[bool] | None): The answers for examples. Defaults to None.
         map_instruction (str | None): The map instruction. Defaults to None.
@@ -407,14 +392,11 @@ def join_optimizer(
     sf_helper_join = run_sem_sim_join(l1, l2, col1_label, col2_label)
     sf_t_pos, sf_t_neg, sf_learn_cost = learn_join_cascade_threshold(
         sf_helper_join,
-        recall_target,
-        precision_target,
         col1_label,
         col2_label,
         model,
         user_instruction,
-        sampling_percentage,
-        delta=failure_probability / 2,
+        cascade_args,
         examples_multimodal_data=examples_multimodal_data,
         examples_answers=examples_answers,
         cot_reasoning=cot_reasoning,
@@ -433,14 +415,11 @@ def join_optimizer(
     msf_helper_join = run_sem_sim_join(mapped_l1, l2, mapped_col1_label, col2_label)
     msf_t_pos, msf_t_neg, msf_learn_cost = learn_join_cascade_threshold(
         msf_helper_join,
-        recall_target,
-        precision_target,
         col1_label,
         col2_label,
         model,
         user_instruction,
-        sampling_percentage,
-        delta=failure_probability / 2,
+        cascade_args,
         examples_multimodal_data=examples_multimodal_data,
         examples_answers=examples_answers,
         cot_reasoning=cot_reasoning,
@@ -479,14 +458,11 @@ def join_optimizer(
 
 def learn_join_cascade_threshold(
     helper_join: pd.DataFrame,
-    recall_target: float,
-    precision_target: float,
     col1_label: str,
     col2_label: str,
     model: lotus.models.LM,
     user_instruction: str,
-    sampling_percentage: float = 0.1,
-    delta: float = 0.2,
+    cascade_args: CascadeArgs,
     examples_multimodal_data: list[dict[str, Any]] | None = None,
     examples_answers: list[bool] | None = None,
     cot_reasoning: list[str] | None = None,
@@ -499,13 +475,12 @@ def learn_join_cascade_threshold(
 
     Args:
         helper_join (pd.DataFrame): The helper join results.
-        recall_target (float): The target recall.
-        precision_target (float): The target precision.
+        cascade_args (CascadeArgs): The cascade arguments.
         col1_label (str): The label for the first column.
         col2_label (str): The label for the second column.
+        model (lotus.models.LM): The language model.
         user_instruction (str): The user instruction for join.
-        sampling_percentage (float): The percentage of the data to sample. Defaults to 0.1.
-        delta (float): The failure probability. Defaults to 0.2.
+        cascade_args (CascadeArgs): The cascade arguments.
         examples_multimodal_data (list[dict[str, Any]] | None): The examples multimodal data. Defaults to None.
         examples_answers (list[bool] | None): The answers for examples. Defaults to None.
         cot_reasoning (list[str] | None): The reasoning for CoT. Defaults to None.
@@ -517,7 +492,7 @@ def learn_join_cascade_threshold(
     # Sample a small subset of the helper join result
     helper_scores = helper_join["_scores"].tolist()
 
-    sample_indices, correction_factors = importance_sampling(helper_scores, sampling_percentage)
+    sample_indices, correction_factors = importance_sampling(helper_scores, cascade_args)
     lotus.logger.info(f"Sampled {len(sample_indices)} out of {len(helper_scores)} helper join results.")
 
     sample_df = helper_join.iloc[sample_indices]
@@ -544,9 +519,7 @@ def learn_join_cascade_threshold(
             proxy_scores=sample_scores,
             oracle_outputs=output.outputs,
             sample_correction_factors=sample_correction_factors,
-            recall_target=recall_target,
-            precision_target=precision_target,
-            delta=delta,
+            cascade_args=cascade_args,
         )
 
         lotus.logger.info(f"Learned cascade thresholds: {(pos_threshold, neg_threshold)}")
@@ -675,7 +648,7 @@ class SemJoinDataframe:
         if (
             (cascade_args is not None)
             and (cascade_args.recall_target is not None or cascade_args.precision_target is not None)
-            and (num_full_join >= lotus.settings.min_join_cascade_size)
+            and (num_full_join >= cascade_args.min_join_cascade_size)
         ):
             cascade_args.recall_target = 1.0 if cascade_args.recall_target is None else cascade_args.recall_target
             cascade_args.precision_target = (
@@ -690,10 +663,7 @@ class SemJoinDataframe:
                 right_on,
                 model,
                 join_instruction,
-                cascade_args.recall_target,
-                cascade_args.precision_target,
-                sampling_percentage=cascade_args.sampling_percentage,
-                failure_probability=cascade_args.failure_probability,
+                cascade_args,
                 examples_multimodal_data=examples_multimodal_data,
                 examples_answers=examples_answers,
                 map_instruction=cascade_args.map_instruction,

--- a/lotus/sem_ops/sem_join.py
+++ b/lotus/sem_ops/sem_join.py
@@ -128,6 +128,7 @@ def sem_join_cascade(
     ids2: list[int],
     col1_label: str,
     col2_label: str,
+    model: lotus.models.LM,
     user_instruction: str,
     recall_target: float,
     precision_target: float,
@@ -195,6 +196,7 @@ def sem_join_cascade(
         l2,
         col1_label,
         col2_label,
+        model,
         user_instruction,
         sampling_percentage=sampling_percentage,
         failure_probability=failure_probability,
@@ -234,7 +236,7 @@ def sem_join_cascade(
             l2_for_l1_index.tolist(),
             col1_label,
             col2_label,
-            lotus.settings.lm,
+            model,
             user_instruction,
             examples_multimodal_data=examples_multimodal_data,
             examples_answers=examples_answers,
@@ -357,6 +359,7 @@ def join_optimizer(
     l2: pd.Series,
     col1_label: str,
     col2_label: str,
+    model: lotus.models.LM,
     user_instruction: str,
     sampling_percentage: float = 0.1,
     failure_probability: float = 0.2,
@@ -408,6 +411,7 @@ def join_optimizer(
         precision_target,
         col1_label,
         col2_label,
+        model,
         user_instruction,
         sampling_percentage,
         delta=failure_probability / 2,
@@ -433,6 +437,7 @@ def join_optimizer(
         precision_target,
         col1_label,
         col2_label,
+        model,
         user_instruction,
         sampling_percentage,
         delta=failure_probability / 2,
@@ -478,6 +483,7 @@ def learn_join_cascade_threshold(
     precision_target: float,
     col1_label: str,
     col2_label: str,
+    model: lotus.models.LM,
     user_instruction: str,
     sampling_percentage: float = 0.1,
     delta: float = 0.2,
@@ -524,7 +530,7 @@ def learn_join_cascade_threshold(
     try:
         output = sem_filter(
             sample_multimodal_data,
-            lotus.settings.lm,
+            model,
             user_instruction,
             default=default,
             examples_multimodal_data=examples_multimodal_data,
@@ -605,6 +611,11 @@ class SemJoinDataframe:
         Returns:
             pd.DataFrame: The dataframe with the new joined columns.
         """
+        model = lotus.settings.lm
+        if model is None:
+            raise ValueError(
+                "The language model must be an instance of LM. Please configure a valid language model using lotus.settings.configure()"
+            )
 
         if isinstance(other, pd.Series):
             if other.name is None:
@@ -677,6 +688,7 @@ class SemJoinDataframe:
                 other.index,
                 left_on,
                 right_on,
+                model,
                 join_instruction,
                 cascade_args.recall_target,
                 cascade_args.precision_target,
@@ -699,7 +711,7 @@ class SemJoinDataframe:
                 other.index,
                 left_on,
                 right_on,
-                lotus.settings.lm,
+                model,
                 join_instruction,
                 examples_multimodal_data=examples_multimodal_data,
                 examples_answers=examples_answers,

--- a/lotus/sem_ops/sem_map.py
+++ b/lotus/sem_ops/sem_map.py
@@ -107,6 +107,11 @@ class SemMapDataframe:
         Returns:
             pd.DataFrame: The dataframe with the new mapped columns.
         """
+        if lotus.settings.lm is None:
+            raise ValueError(
+                "The language model must be an instance of LM. Please configure a valid language model using lotus.settings.configure()"
+            )
+
         col_li = lotus.nl_expression.parse_cols(user_instruction)
 
         # check that column exists

--- a/lotus/sem_ops/sem_search.py
+++ b/lotus/sem_ops/sem_search.py
@@ -46,6 +46,11 @@ class SemSearchDataframe:
         if K is not None:
             # get retriever model and index
             rm = lotus.settings.rm
+            if rm is None:
+                raise ValueError(
+                    "The retrieval model must be an instance of RM. Please configure a valid retrieval model using lotus.settings.configure()"
+                )
+
             col_index_dir = self._obj.attrs["index_dirs"][col_name]
             if rm.index_dir != col_index_dir:
                 rm.load_index(col_index_dir)
@@ -83,6 +88,9 @@ class SemSearchDataframe:
             new_df = self._obj
 
         if n_rerank is not None:
+            if lotus.settings.reranker is None:
+                raise ValueError("Reranker not found in settings")
+
             docs = new_df[col_name].tolist()
             reranked_output: RerankerOutput = lotus.settings.reranker(query, docs, n_rerank)
             reranked_idxs = reranked_output.indices

--- a/lotus/settings.py
+++ b/lotus/settings.py
@@ -11,15 +11,6 @@ class Settings:
     # Cache settings
     enable_cache: bool = False
 
-    # Filter cascade settings
-    cascade_IS_weight: float = 0.5
-    cascade_num_calibration_quantiles: int = 50
-
-    # Join cascade settings
-    min_join_cascade_size: int = 100
-    cascade_IS_max_sample_range: int = 250
-    cascade_IS_random_seed: int | None = None
-
     def configure(self, **kwargs):
         for key, value in kwargs.items():
             if not hasattr(self, key):

--- a/lotus/settings.py
+++ b/lotus/settings.py
@@ -1,122 +1,30 @@
-# type: ignore
-
-import copy
-import threading
-from contextlib import contextmanager
-from typing import Any, Generator
+import lotus.models
 
 
-# This code was adapted from DSPy: https://github.com/stanfordnlp/dspy/blob/main/dsp/utils/settings.py
-class dotdict(dict[str, Any]):
-    def __getattr__(self, key: str) -> Any:
-        if key.startswith("__") and key.endswith("__"):
-            return super().__getattr__(key)
-        try:
-            return self[key]
-        except KeyError:
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'")
+class Settings:
+    # Models
+    lm: lotus.models.LM | None = None
+    rm: lotus.models.RM | None = None
+    helper_lm: lotus.models.LM | None = None
+    reranker: lotus.models.Reranker | None = None
 
-    def __setattr__(self, key: str, value: Any) -> None:
-        if key.startswith("__") and key.endswith("__"):
-            super().__setattr__(key, value)
-        else:
-            self[key] = value
+    # Cache settings
+    enable_cache: bool = False
 
-    def __delattr__(self, key: str) -> None:
-        if key.startswith("__") and key.endswith("__"):
-            super().__delattr__(key)
-        else:
-            del self[key]
+    # Filter cascade settings
+    cascade_IS_weight: float = 0.5
+    cascade_num_calibration_quantiles: int = 50
 
-    def __deepcopy__(self, memo: Any) -> "dotdict":
-        # Use the default dict copying method to avoid infinite recursion.
-        return dotdict(copy.deepcopy(dict(self), memo))
+    # Join cascade settings
+    min_join_cascade_size: int = 100
+    cascade_IS_max_sample_range: int = 250
+    cascade_IS_random_seed: int | None = None
 
-
-class Settings(object):
-    """configuration settings."""
-
-    _instance = None
-
-    def __new__(cls) -> "Settings":
-        """
-        Singleton Pattern. See https://python-patterns.guide/gang-of-four/singleton/
-        """
-
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-            cls._instance.lock = threading.Lock()
-            cls._instance.main_tid = threading.get_ident()
-            cls._instance.main_stack = []
-            cls._instance.stack_by_thread = {}
-            cls._instance.stack_by_thread[threading.get_ident()] = cls._instance.main_stack
-
-            config = dotdict(
-                lm=None,
-                helper_lm=None,
-                rm=None,
-            )
-            cls._instance.__append(config)
-
-        return cls._instance
-
-    @property
-    def config(self) -> dotdict:
-        thread_id = threading.get_ident()
-        if thread_id not in self.stack_by_thread:
-            self.stack_by_thread[thread_id] = [self.main_stack[-1].copy()]
-        return self.stack_by_thread[thread_id][-1]
-
-    def __getattr__(self, name: str) -> Any:
-        if hasattr(self.config, name):
-            return getattr(self.config, name)
-
-        if name in self.config:
-            return self.config[name]
-
-        super().__getattr__(name)
-
-    def __append(self, config: dotdict) -> None:
-        thread_id = threading.get_ident()
-        if thread_id not in self.stack_by_thread:
-            self.stack_by_thread[thread_id] = [self.main_stack[-1].copy()]
-        self.stack_by_thread[thread_id].append(config)
-
-    def __pop(self) -> None:
-        thread_id = threading.get_ident()
-        if thread_id in self.stack_by_thread:
-            self.stack_by_thread[thread_id].pop()
-
-    def configure(self, inherit_config: bool = True, **kwargs):
-        """Set configuration settings.
-
-        Args:
-            inherit_config (bool, optional): Set configurations for the given, and use existing configurations for the rest. Defaults to True.
-        """
-        if inherit_config:
-            config = {**self.config, **kwargs}
-        else:
-            config = {**kwargs}
-
-        self.__append(config)
-
-    @contextmanager
-    def context(self, inherit_config: bool = True, **kwargs: Any) -> Generator[None, None, None]:
-        self.configure(inherit_config=inherit_config, **kwargs)
-
-        try:
-            yield
-        finally:
-            self.__pop()
-
-    def __repr__(self) -> str:
-        return repr(self.config)
+    def configure(self, **kwargs):
+        for key, value in kwargs.items():
+            if not hasattr(self, key):
+                raise ValueError(f"Invalid setting: {key}")
+            setattr(self, key, value)
 
 
-# set defaults
 settings = Settings()
-settings.configure(enable_cache=False)
-settings.configure(cascade_IS_weight=0.5, cascade_num_calibration_quantiles=50)  # Filter cascade settings
-settings.configure(
-    min_join_cascade_size=100, cascade_IS_max_sample_range=250, cascade_IS_random_seed=None
-)  # Join cascade settings

--- a/lotus/types.py
+++ b/lotus/types.py
@@ -88,12 +88,21 @@ class SemanticJoinOutput(StatsMixin):
 
 
 class CascadeArgs(BaseModel):
-    recall_target: float | None = None
-    precision_target: float | None = None
+    recall_target: float = 0.8
+    precision_target: float = 0.8
     sampling_percentage: float = 0.1
     failure_probability: float = 0.2
     map_instruction: str | None = None
     map_examples: pd.DataFrame | None = None
+
+    # Filter cascade args
+    cascade_IS_weight: float = 0.5
+    cascade_num_calibration_quantiles: int = 50
+
+    # Join cascade args
+    min_join_cascade_size: int = 100
+    cascade_IS_max_sample_range: int = 250
+    cascade_IS_random_seed: int | None = None
 
     # to enable pandas
     class Config:

--- a/lotus/utils.py
+++ b/lotus/utils.py
@@ -39,6 +39,11 @@ def cluster(col_name: str, ncentroids: int) -> Callable[[pd.DataFrame, int, bool
 
         # get rmodel and index
         rm = lotus.settings.rm
+        if rm is None:
+            raise ValueError(
+                "The retrieval model must be an instance of RM. Please configure a valid retrieval model using lotus.settings.configure()"
+            )
+
         try:
             col_index_dir = df.attrs["index_dirs"][col_name]
         except KeyError:


### PR DESCRIPTION
Better to have settings be very explicit, rather than unstructured. Making the change led to a bunch of `mypy` complaints that required some assertions to be made. The changes maintain the same user-facing API by providing a `configure` method on `lotus.settings`