### PR TITLE
Try out openhouse connector on top of lotus and Trino connector 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ docs/_build
 .ruff_cache
 .mypy_cache
 .pytest_cache
+.venv/
+.python-version
+.vscode/

--- a/demo_data_loader.py
+++ b/demo_data_loader.py
@@ -1,0 +1,7 @@
+from examples.op_examples.openhouse_connector import OpenHouse
+from openhouse_config import connection_params
+
+openhouse = OpenHouse(connection_params)
+df = openhouse.table("openhouse.u_openhouse.lotus_test")
+print(df.head())  # Now connects and fetches data
+print(df.describe())  # Uses cached data from previous fetch

--- a/examples/op_examples/filter.py
+++ b/examples/op_examples/filter.py
@@ -3,7 +3,7 @@ import pandas as pd
 import lotus
 from lotus.models import LM
 
-lm = LM(model="gpt-4o-mini")
+lm = LM(model="ollama/llama3.2", api_base="http://localhost:11434")
 
 lotus.settings.configure(lm=lm)
 data = {

--- a/examples/op_examples/openhouse_connector.py
+++ b/examples/op_examples/openhouse_connector.py
@@ -1,0 +1,54 @@
+from typing import Optional, Any
+import pandas as pd
+import trino
+
+class LazyTable:
+    def __init__(self, table_name: str, connection_params: dict):
+        self._table_name = table_name
+        self._connection_params = connection_params
+        self._connection = None
+        self._query = f"SELECT * FROM {table_name}"
+        self._df: Optional[pd.DataFrame] = None
+
+    def _ensure_connection(self):
+        if self._connection is None:
+            self._connection = trino.dbapi.connect(**self._connection_params)
+
+    def _ensure_data(self):
+        if self._df is None:
+            self._ensure_connection()
+            cur = self._connection.cursor()
+            cur.execute(self._query)
+            columns = [desc[0] for desc in cur.description]
+            # Convert results to DataFrame
+            self._df = pd.DataFrame(cur.fetchall(), columns=columns)
+        return self._df
+
+    # Implement pandas DataFrame methods that will trigger evaluation
+    def head(self, n: int = 5) -> pd.DataFrame:
+        return self._ensure_data().head(n)
+
+    def tail(self, n: int = 5) -> pd.DataFrame:
+        return self._ensure_data().tail(n)
+    
+    def describe(self) -> pd.DataFrame:
+        return self._ensure_data().describe()
+
+    # You can override other pandas methods as needed
+    def __getattr__(self, name: str) -> Any:
+        # This will be called for any attribute not explicitly defined
+        def method(*args, **kwargs):
+            # Ensure we have the data and then call the pandas method
+            df = self._ensure_data()
+            if hasattr(df, name):
+                return getattr(df, name)(*args, **kwargs)
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+        return method
+
+class OpenHouse:
+    def __init__(self, connection_params: dict):
+        self._connection_params = connection_params
+
+    # format of the table_name is like: openhouse.u_openhouse.lotus_test
+    def table(self, table_name: str) -> LazyTable:
+        return LazyTable(table_name, self._connection_params)

--- a/examples/op_examples/try_trino_conn.py
+++ b/examples/op_examples/try_trino_conn.py
@@ -1,0 +1,21 @@
+import trino
+import pandas as pd
+
+#TODO: Fix the connection params to make it work
+conn=trino.dbapi.connect(
+    host='******.corp.******.com',
+    port=***,
+    user='lesun',
+    catalog='openhouse',
+    http_scheme='https',
+    # TODO: Can we avoid using the password here? 
+    auth=trino.auth.BasicAuthentication("", ""),
+)
+cur = conn.cursor()
+cur.execute("SELECT * from openhouse.db.table")
+
+columns = [desc[0] for desc in cur.description]
+# Convert results to DataFrame
+df = pd.DataFrame(cur.fetchall(), columns=columns)
+# Now you can work with the DataFrame
+print(df)

--- a/openhouse_config.py
+++ b/openhouse_config.py
@@ -1,0 +1,14 @@
+import os
+import trino
+
+connection_params = {
+    'host': os.getenv('TRINO_HOST', '******.corp.******.com'),
+    'port': int(os.getenv('TRINO_PORT', '***')),
+    'user': os.getenv('TRINO_USER'),
+    'catalog': os.getenv('TRINO_CATALOG', 'openhouse'),
+    'http_scheme': os.getenv('TRINO_SCHEME', 'https'),
+    'auth': trino.auth.BasicAuthentication(
+        os.getenv('TRINO_USER'),
+        os.getenv('TRINO_PASSWORD')
+    )
+} 


### PR DESCRIPTION
- Add a toy openhouse connector to lazily materialize a pandas Dataframe using Trino's connector as the backbone. 
- Add an example to demonstrate how to use that from users' perspective 

next step: 
- stitch with the index provided separately instead of relying on RM within lotus to explicitly build it during read time and use it there. 